### PR TITLE
Fix for ViolentMonkey issues

### DIFF
--- a/JavaRoomStockComments.meta.js
+++ b/JavaRoomStockComments.meta.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Stock Comments
 // @namespace    https://github.com/geisterfurz007
-// @version      0.3.5
+// @version      0.3.6
 // @description  Easily send stock messages with the click of a button
 // @author       geisterfurz007
 // @match        https://chat.stackoverflow.com/rooms/139/*

--- a/JavaRoomStockComments.user.js
+++ b/JavaRoomStockComments.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Stock Comments
 // @namespace    https://github.com/geisterfurz007
-// @version      0.3.5
+// @version      0.3.6
 // @description  Easily send stock messages with the click of a button
 // @author       geisterfurz007
 // @match        https://chat.stackoverflow.com/rooms/139/*

--- a/JavaRoomStockComments.user.js
+++ b/JavaRoomStockComments.user.js
@@ -13,6 +13,8 @@
 // ==/UserScript==
 
 const room = 139;
+if(GM == null)
+    var GM;
 
 
 (function() {


### PR DESCRIPTION
For some reason, using ViolentMonkey, GM is null and the script throws an exception on `GM = {}`. See also [the documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Undeclared_var) for that specifically. 

It needs to be declared with a `var`, otherwise it will throw an exception. Since it works fine with TM, that likely means it's not a problem there, but this covers the userscripts that support GM_*, but doesn't have a `GM` variable by default. 

Basically this initializes it to null, which declares it in a possibly safer way. If it's null at the time of script initialization, it creates it. Adding `var GM = {}` inside the function won't work with strict mode (where scoping rules are slightly less horrible)